### PR TITLE
fix build failure with gcc-14

### DIFF
--- a/src/ifd/ifdhandler.c
+++ b/src/ifd/ifdhandler.c
@@ -236,7 +236,7 @@ static void ifdhandler_run(ifd_reader_t * reader)
 		sock->fd = -1;
 	}
 	else {
-		sock->fd = ifd_get_eventfd(reader, &sock->events);
+		sock->fd = ifd_get_eventfd(reader, (short int *)&sock->events);
 	}
 	if (sock->fd == -1) {
 		ifd_debug(1, "events inactive for reader %s", reader->name);

--- a/src/ifd/process.c
+++ b/src/ifd/process.c
@@ -366,7 +366,7 @@ static int do_verify(ifd_reader_t * reader, int unit, ct_tlv_parser_t * args,
 	ct_tlv_get_int(args, CT_TAG_TIMEOUT, &timeout);
 	if (ct_tlv_get_string(args, CT_TAG_MESSAGE, msgbuf, sizeof(msgbuf)) > 0)
 		message = msgbuf;
-	if (!ct_tlv_get_opaque(args, CT_TAG_PIN_DATA, &data, &data_len))
+	if (!ct_tlv_get_opaque(args, CT_TAG_PIN_DATA, &data, (size_t *)&data_len))
 		return IFD_ERROR_MISSING_ARG;
 
 	rc = ifd_card_perform_verify(reader, unit, timeout, message,


### PR DESCRIPTION
When build with gcc14 the following error occurred:
| ../../../openct-0.6.20/src/ifd/ifdhandler.c: In function 'ifdhandler_run':
| ../../../openct-0.6.20/src/ifd/ifdhandler.c:239:52: error: passing argument 2 of 'ifd_get_eventfd' from incompatible pointer type [-Wincompatible-pointer-types]
|   239 |                 sock->fd = ifd_get_eventfd(reader, &sock->events);
|       |                                                    ^~~~~~~~~~~~~
|       |                                                    |
|       |                                                    int *
| In file included from ../../../openct-0.6.20/src/ifd/internal.h:17,
|                  from ../../../openct-0.6.20/src/ifd/ifdhandler.c:7:
| ../../../openct-0.6.20/src/include/openct/ifd.h:182:65: note: expected 'short int *' but argument is of type 'int *'
|   182 | extern int                      ifd_get_eventfd(ifd_reader_t *, short *);
|       |                                                                 ^~~~~~~

| ../../../openct-0.6.20/src/ifd/process.c: In function 'do_memory_write':
| ../../../openct-0.6.20/src/ifd/process.c:461:61: error: passing argument 4 of 'ct_tlv_get_opaque' from incompatible pointer type -incompatible-pointer-types]
|   461 |             || !ct_tlv_get_opaque(args, CT_TAG_DATA, &data, &data_len))
|       |                                                             ^~~~~~~~~
|       |                                                             |
|       |                                                             unsigned int *
| In file included from ../../../openct-0.6.20/src/ifd/process.c:20:
| ../../../openct-0.6.20/src/include/openct/tlv.h:40:62: note: expected 'size_t *' {aka 'long unsigned int *'} but argument is of type 'unsigned int *'
|    40 |                                 ifd_tag_t, unsigned char **, size_t *);
